### PR TITLE
feat: 게시글 수정하기 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/ArticleController.java
+++ b/src/main/java/com/yourssu/blog/controller/ArticleController.java
@@ -1,14 +1,13 @@
 package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
+import com.yourssu.blog.controller.dto.ArticleEditRequest;
 import com.yourssu.blog.service.ArticleService;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @RequiredArgsConstructor
 @RestController
@@ -26,6 +25,12 @@ public class ArticleController {
     @PostMapping
     public ResponseEntity<ArticleResponse> save(@RequestBody ArticleCreateRequest request) {
         ArticleResponse article = articleService.saveArticle(request.toArticleSaveRequest());
+        return ResponseEntity.status(HttpStatus.CREATED).body(article);
+    }
+
+    @PutMapping("/{articleId}")
+    public ResponseEntity<ArticleResponse> edit(@PathVariable Long articleId, @RequestBody ArticleEditRequest request) {
+        ArticleResponse article = articleService.update(request.toArticleUpdatedRequest(articleId));
         return ResponseEntity.status(HttpStatus.CREATED).body(article);
     }
 }

--- a/src/main/java/com/yourssu/blog/controller/dto/ArticleEditRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/ArticleEditRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.ArticleUpdateRequest;
+
+public record ArticleEditRequest(String email, String password, String title, String content) {
+
+    public ArticleUpdateRequest toArticleUpdatedRequest(Long articleId) {
+        return new ArticleUpdateRequest(articleId, email, password, title, content);
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/Article.java
+++ b/src/main/java/com/yourssu/blog/model/Article.java
@@ -34,4 +34,9 @@ public class Article extends BaseEntity {
         this.title = title;
         this.content = content;
     }
+
+    public void update(Article article) {
+        this.title = article.title;
+        this.content = article.content;
+    }
 }

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -4,6 +4,7 @@ import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.repository.ArticleRepository;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
+import com.yourssu.blog.service.dto.ArticleUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,7 @@ public class ArticleService {
     @Transactional
     public ArticleResponse saveArticle(final ArticleSaveRequest request) {
         Article article = request.getArticle();
-        articleRepository.save(article);
-        return ArticleResponse.of(article);
+        Article savedArticle = articleRepository.save(article);
+        return ArticleResponse.of(savedArticle);
     }
 }

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -28,4 +28,12 @@ public class ArticleService {
         Article savedArticle = articleRepository.save(article);
         return ArticleResponse.of(savedArticle);
     }
+
+    @Transactional
+    public ArticleResponse update(final ArticleUpdateRequest request) {
+        Article article = request.getArticle();
+        Article updatedArticle = articleRepository.get(article.getArticleId());
+        updatedArticle.update(article);
+        return ArticleResponse.of(updatedArticle);
+    }
 }

--- a/src/main/java/com/yourssu/blog/service/dto/ArticleUpdateRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/ArticleUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.Article;
+
+public record ArticleUpdateRequest(Long articleId, String email, String password, String title, String content) {
+
+    public Article getArticle() {
+        return new Article(articleId, email, title, content);
+    }
+}

--- a/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
@@ -1,14 +1,15 @@
 package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
+import com.yourssu.blog.controller.dto.ArticleEditRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.support.acceptance.AcceptanceTest;
 import com.yourssu.blog.support.common.fixture.ArticleFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokeGet;
-import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.*;
+import static com.yourssu.blog.support.common.fixture.ArticleFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -18,8 +19,7 @@ class ArticleAcceptanceTest extends AcceptanceTest {
     @Test
     void 게시글_생성을_요청한다() {
         // Given
-        ArticleFixture article = ArticleFixture.LEO;
-        ArticleCreateRequest request = article.getArticleCreateRequest();
+        ArticleCreateRequest request = LEO.getArticleCreateRequest();
 
         // When
         invokePost("/api/articles", request);
@@ -32,5 +32,27 @@ class ArticleAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual.getArticleId()).isEqualTo(1)
         );
+    }
+
+    @Test
+    void 게시글_수정을_요청한다() {
+        // Given
+        ArticleResponse article = createArticle(LEO);
+
+        // When
+        ArticleEditRequest request = EVOLVED_LEO.getArticleEditRequest();
+
+        var response = invokePut("/api/articles/" + article.getArticleId(), request);
+        ArticleResponse actual = response.as(ArticleResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(actual.getTitle()).isEqualTo(request.title())
+        );
+    }
+
+    private static ArticleResponse createArticle(ArticleFixture article) {
+        ArticleCreateRequest request = article.getArticleCreateRequest();
+        return invokePost("/api/articles", request).as(ArticleResponse.class);
     }
 }

--- a/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
@@ -1,12 +1,14 @@
 package com.yourssu.blog.service;
 
+import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
-import com.yourssu.blog.support.common.fixture.ArticleFixture;
+import com.yourssu.blog.service.dto.ArticleUpdateRequest;
 import com.yourssu.blog.support.service.ApplicationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static com.yourssu.blog.support.common.fixture.ArticleFixture.*;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @ApplicationTest
@@ -18,11 +20,22 @@ class ArticleServiceTest {
     @Test
     @DisplayName("게시글을 생성한다.")
     void save() {
-        ArticleFixture article = ArticleFixture.LEO;
-        ArticleSaveRequest request = article.getArticleSaveRequest();
+        ArticleSaveRequest request = LEO.getArticleSaveRequest();
 
         assertThatNoException().isThrownBy(
                 () -> articleService.saveArticle(request)
+        );
+    }
+
+    @Test
+    @DisplayName("게시글을 수정한다.")
+    void update() {
+        ArticleResponse given = articleService.saveArticle(LEO.getArticleSaveRequest());
+
+        ArticleUpdateRequest request = EVOLVED_LEO.getArticleUpdateRequest(given.getArticleId());
+
+        assertThatNoException().isThrownBy(
+                () -> articleService.update(request)
         );
     }
 }

--- a/src/test/java/com/yourssu/blog/support/acceptance/AcceptanceContext.java
+++ b/src/test/java/com/yourssu/blog/support/acceptance/AcceptanceContext.java
@@ -26,28 +26,6 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokeGetWithToken(String path, String token,
-                                                                   Object... params) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(token)
-                .when()
-                .get(path, params)
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> invokeGetWithTokenAndQueryParams(String path,
-                                                                                 String token,
-                                                                                 Map<String, Object> params) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(token)
-                .queryParams(params)
-                .when()
-                .get(path)
-                .then().log().all()
-                .extract();
-    }
-
     public static ExtractableResponse<Response> invokePost(String path, Object data) {
         return RestAssured.given().log().all()
                 .body(data)
@@ -58,22 +36,8 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokePostWithToken(String path, String token,
-                                                                    Object data) {
+    public static ExtractableResponse<Response> invokePut(String path, Object data) {
         return RestAssured.given().log().all()
-                .auth().oauth2(token)
-                .body(data)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post(path)
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> invokePutWithToken(String path, String token,
-                                                                   Object data) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(token)
                 .body(data)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
@@ -82,9 +46,8 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokePutWithToken(String path, String token) {
+    public static ExtractableResponse<Response> invokePut(String path) {
         return RestAssured.given().log().all()
-                .auth().oauth2(token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .put(path)
@@ -92,9 +55,8 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokePatchWithToken(String path, String token) {
+    public static ExtractableResponse<Response> invokePatch(String path) {
         return RestAssured.given().log().all()
-                .auth().oauth2(token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .patch(path)
@@ -102,9 +64,8 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokeDeleteWithToken(String path, String token) {
+    public static ExtractableResponse<Response> invokeDelete(String path) {
         return RestAssured.given().log().all()
-                .auth().oauth2(token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .delete(path)
@@ -112,13 +73,24 @@ public class AcceptanceContext {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> invokeDeleteWithToken(String path, String token, Object data) {
+    public static ExtractableResponse<Response> invokeDelete(String path, Object data) {
+        return RestAssured.given().log().all()
+                .body(data)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete(path)
+                .then().log().all()
+                .extract();
+    }
+
+    @Deprecated
+    public static ExtractableResponse<Response> invokePostWithToken(String path, String token, Object data) {
         return RestAssured.given().log().all()
                 .auth().oauth2(token)
                 .body(data)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .delete(path)
+                .post(path)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
@@ -1,16 +1,21 @@
 package com.yourssu.blog.support.common.fixture;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
+import com.yourssu.blog.controller.dto.ArticleEditRequest;
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
-import org.apache.catalina.User;
+import com.yourssu.blog.service.dto.ArticleUpdateRequest;
 
 public enum ArticleFixture {
 
     LEO(UserFixture.LEO,
             "leo title",
             "leo context"
-    );
+    ),
+    EVOLVED_LEO(UserFixture.LEO,
+            "leo evolved title",
+            "leo evolved context"
+            );
 
     private final UserFixture userFixture;
     private final String title;
@@ -32,5 +37,13 @@ public enum ArticleFixture {
 
     public ArticleSaveRequest getArticleSaveRequest() {
         return new ArticleSaveRequest(userFixture.getEmail(), userFixture.getPassword(), title, context);
+    }
+
+    public ArticleEditRequest getArticleEditRequest() {
+        return new ArticleEditRequest(userFixture.getEmail(), userFixture.getPassword(), title, context);
+    }
+
+    public ArticleUpdateRequest getArticleUpdateRequest(Long articleId) {
+        return new ArticleUpdateRequest(articleId, userFixture.getEmail(), userFixture.getPassword(), title, context);
     }
 }


### PR DESCRIPTION
### 특이사항
- PUT 요청 자원 생성과 관계없이 201 반환, 변경 사항 없음&변경 되지 않을 경우 204 반환으로 변경 필요함
- 게시글 작성자와 회원가입 여부를 고려하지 않음
- 게시글 저장 기능에서 반환하는 엔티티를 저장된 엔티티로 수정
- AcceptanceContext를 토큰 미사용 하는 경우로 변경

### 구현 API 예시
1. PUT /api/articles/1 => 201 Created

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "title" : "title-edited",
    "content" : "content-edited"
}
```

**Response Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "title" : "title-edited",
    "content" : "content-edited"
}
```
