### PR TITLE
feat: 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/ArticleController.java
+++ b/src/main/java/com/yourssu/blog/controller/ArticleController.java
@@ -2,6 +2,7 @@ package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
 import com.yourssu.blog.controller.dto.ArticleEditRequest;
+import com.yourssu.blog.controller.dto.ArticleRemoveRequest;
 import com.yourssu.blog.service.ArticleService;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,11 @@ public class ArticleController {
     public ResponseEntity<ArticleResponse> edit(@PathVariable Long articleId, @RequestBody ArticleEditRequest request) {
         ArticleResponse article = articleService.update(request.toArticleUpdatedRequest(articleId));
         return ResponseEntity.status(HttpStatus.CREATED).body(article);
+    }
+
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<Void> remove(@PathVariable Long articleId, @RequestBody ArticleRemoveRequest request) {
+        articleService.delete(request.toArticleDeleteRequest(articleId));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.yourssu.blog.service;
 
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.repository.ArticleRepository;
+import com.yourssu.blog.service.dto.ArticleDeleteRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
 import com.yourssu.blog.service.dto.ArticleUpdateRequest;
@@ -35,5 +36,10 @@ public class ArticleService {
         Article updatedArticle = articleRepository.get(article.getArticleId());
         updatedArticle.update(article);
         return ArticleResponse.of(updatedArticle);
+    }
+
+    public void delete(final ArticleDeleteRequest request) {
+        Article article = articleRepository.get(request.articleId());
+        articleRepository.delete(article);
     }
 }

--- a/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
 import com.yourssu.blog.controller.dto.ArticleEditRequest;
+import com.yourssu.blog.controller.dto.ArticleRemoveRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.support.acceptance.AcceptanceTest;
 import com.yourssu.blog.support.common.fixture.ArticleFixture;
@@ -48,6 +49,21 @@ class ArticleAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
                 () -> assertThat(actual.getTitle()).isEqualTo(request.title())
+        );
+    }
+
+    @Test
+    void 게시글_삭제를_요청한다() {
+        // Given
+        ArticleResponse article = createArticle(LEO);
+
+        // When
+        ArticleRemoveRequest request = LEO.getArticleRemoveRequest();
+
+        var response = invokeDelete("/api/articles/" + article.getArticleId(), request);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
         );
     }
 

--- a/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
@@ -1,5 +1,6 @@
 package com.yourssu.blog.service;
 
+import com.yourssu.blog.service.dto.ArticleDeleteRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
 import com.yourssu.blog.service.dto.ArticleUpdateRequest;
@@ -36,6 +37,18 @@ class ArticleServiceTest {
 
         assertThatNoException().isThrownBy(
                 () -> articleService.update(request)
+        );
+    }
+
+    @Test
+    @DisplayName("게시글을 삭제한다.")
+    void delete() {
+        ArticleResponse given = articleService.saveArticle(LEO.getArticleSaveRequest());
+
+        ArticleDeleteRequest request = LEO.getArticleDeleteRequest(given.getArticleId());
+
+        assertThatNoException().isThrownBy(
+                () -> articleService.delete(request)
         );
     }
 }

--- a/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
@@ -2,7 +2,9 @@ package com.yourssu.blog.support.common.fixture;
 
 import com.yourssu.blog.controller.dto.ArticleCreateRequest;
 import com.yourssu.blog.controller.dto.ArticleEditRequest;
+import com.yourssu.blog.controller.dto.ArticleRemoveRequest;
 import com.yourssu.blog.model.Article;
+import com.yourssu.blog.service.dto.ArticleDeleteRequest;
 import com.yourssu.blog.service.dto.ArticleSaveRequest;
 import com.yourssu.blog.service.dto.ArticleUpdateRequest;
 
@@ -46,4 +48,13 @@ public enum ArticleFixture {
     public ArticleUpdateRequest getArticleUpdateRequest(Long articleId) {
         return new ArticleUpdateRequest(articleId, userFixture.getEmail(), userFixture.getPassword(), title, context);
     }
+
+    public ArticleRemoveRequest getArticleRemoveRequest() {
+        return new ArticleRemoveRequest(userFixture.getEmail(), userFixture.getPassword());
+    }
+
+    public ArticleDeleteRequest getArticleDeleteRequest(Long articleId) {
+        return new ArticleDeleteRequest(articleId, userFixture.getEmail(), userFixture.getPassword());
+    }
+
 }


### PR DESCRIPTION
### 특이사항
- 게시글이 무조건 삭제되는 경우만 고려하여 204 상태 코드를 반환한다.
- 예외 상황을 고려하지 않는다.
- 게시글 존재 여부와 게시글 작성자 일치 여부를 고려하지 않는다.
- 인증, 인가 기능이 구현되면 RequestBody를 받는 현재 api를 Deprecated한다.

### API 명세
1. DELETE /api/articles/{articleId} => 204 No Content

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
}
```
