### PR TITLE
feat: 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/CommentController.java
+++ b/src/main/java/com/yourssu/blog/controller/CommentController.java
@@ -1,0 +1,30 @@
+package com.yourssu.blog.controller;
+
+import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.service.CommentService;
+import com.yourssu.blog.service.dto.CommentRequest;
+import com.yourssu.blog.service.dto.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/articles")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{articleId}/comments/{commentId}")
+    public ResponseEntity<CommentResponse> show(@PathVariable Long articleId, @PathVariable Long commentId) {
+        CommentResponse comment = commentService.findCommentById(new CommentRequest(articleId, commentId));
+        return ResponseEntity.ok(comment);
+    }
+
+    @PostMapping("/{articleId}/comments")
+    public ResponseEntity<CommentResponse> create(@PathVariable Long articleId, @RequestBody CommentCreateRequest request) {
+        CommentResponse comment = commentService.save(request.toCommentSaveRequest(articleId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(comment);
+    }
+}

--- a/src/main/java/com/yourssu/blog/controller/CommentController.java
+++ b/src/main/java/com/yourssu/blog/controller/CommentController.java
@@ -11,18 +11,18 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/articles")
+@RequestMapping("/api/articles/{articleId}/comments")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @GetMapping("/{articleId}/comments/{commentId}")
+    @GetMapping("/{commentId}")
     public ResponseEntity<CommentResponse> show(@PathVariable Long articleId, @PathVariable Long commentId) {
         CommentResponse comment = commentService.findCommentById(new CommentRequest(articleId, commentId));
         return ResponseEntity.ok(comment);
     }
 
-    @PostMapping("/{articleId}/comments")
+    @PostMapping
     public ResponseEntity<CommentResponse> create(@PathVariable Long articleId, @RequestBody CommentCreateRequest request) {
         CommentResponse comment = commentService.save(request.toCommentSaveRequest(articleId));
         return ResponseEntity.status(HttpStatus.CREATED).body(comment);

--- a/src/main/java/com/yourssu/blog/controller/dto/CommentCreateRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/CommentCreateRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.CommentSaveRequest;
+
+public record CommentCreateRequest(String email, String password, String content) {
+
+    public CommentSaveRequest toCommentSaveRequest(Long articleId) {
+        return new CommentSaveRequest(articleId, email, password, content);
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/Comment.java
+++ b/src/main/java/com/yourssu/blog/model/Comment.java
@@ -1,0 +1,37 @@
+package com.yourssu.blog.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String content;
+
+    public Comment(Article article, String email, String content) {
+        this(null, article, email, content);
+    }
+
+    public Comment(Long commentId, Article article, String email, String content) {
+        this.commentId = commentId;
+        this.article = article;
+        this.email = email;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/repository/CommentRepository.java
+++ b/src/main/java/com/yourssu/blog/model/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.yourssu.blog.model.repository;
+
+import com.yourssu.blog.model.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    default Comment get(Long id) {
+        return findById(id).orElseThrow(RuntimeException::new);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -23,14 +23,12 @@ public class ArticleService {
         return ArticleResponse.of(article);
     }
 
-    @Transactional
     public ArticleResponse saveArticle(final ArticleSaveRequest request) {
         Article article = request.getArticle();
         Article savedArticle = articleRepository.save(article);
         return ArticleResponse.of(savedArticle);
     }
 
-    @Transactional
     public ArticleResponse update(final ArticleUpdateRequest request) {
         Article article = request.getArticle();
         Article updatedArticle = articleRepository.get(article.getArticleId());

--- a/src/main/java/com/yourssu/blog/service/CommentService.java
+++ b/src/main/java/com/yourssu/blog/service/CommentService.java
@@ -1,0 +1,33 @@
+package com.yourssu.blog.service;
+
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.Comment;
+import com.yourssu.blog.model.repository.ArticleRepository;
+import com.yourssu.blog.model.repository.CommentRepository;
+import com.yourssu.blog.service.dto.CommentRequest;
+import com.yourssu.blog.service.dto.CommentResponse;
+import com.yourssu.blog.service.dto.CommentSaveRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public CommentResponse findCommentById(final CommentRequest commentRequest) {
+        Comment comment = commentRepository.get(commentRequest.commentId());
+        return CommentResponse.of(comment);
+    }
+
+    public CommentResponse save(final CommentSaveRequest request) {
+        Article article = articleRepository.get(request.articleId());
+        Comment comment = commentRepository.save(request.getComment(article));
+        return CommentResponse.of(comment);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/dto/CommentRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/CommentRequest.java
@@ -1,0 +1,4 @@
+package com.yourssu.blog.service.dto;
+
+public record CommentRequest(Long articleId, Long commentId) {
+}

--- a/src/main/java/com/yourssu/blog/service/dto/CommentResponse.java
+++ b/src/main/java/com/yourssu/blog/service/dto/CommentResponse.java
@@ -1,0 +1,32 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.Comment;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CommentResponse implements Serializable {
+
+    private Long commentId;
+    private String email;
+    private String content;
+
+    public CommentResponse(final Long commentId,
+                           final String email,
+                           final String content) {
+        this.commentId = commentId;
+        this.email = email;
+        this.content = content;
+    }
+
+    public static CommentResponse of(final Comment comment) {
+        return new CommentResponse(
+                comment.getCommentId(),
+                comment.getEmail(),
+                comment.getContent());
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/dto/CommentSaveRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/CommentSaveRequest.java
@@ -1,0 +1,11 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.Comment;
+
+public record CommentSaveRequest(Long articleId, String email, String password, String content) {
+
+    public Comment getComment(Article article) {
+        return new Comment(article, email, content);
+    }
+}

--- a/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/ArticleAcceptanceTest.java
@@ -67,7 +67,7 @@ class ArticleAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private static ArticleResponse createArticle(ArticleFixture article) {
+    public static ArticleResponse createArticle(ArticleFixture article) {
         ArticleCreateRequest request = article.getArticleCreateRequest();
         return invokePost("/api/articles", request).as(ArticleResponse.class);
     }

--- a/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
@@ -1,0 +1,40 @@
+package com.yourssu.blog.controller;
+
+import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.service.dto.ArticleResponse;
+import com.yourssu.blog.service.dto.CommentResponse;
+import com.yourssu.blog.support.acceptance.AcceptanceTest;
+import com.yourssu.blog.support.common.fixture.ArticleFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
+import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class CommentAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 댓글_생성을_요청한다() {
+        // Given
+        ArticleResponse article = ArticleAcceptanceTest.createArticle(ArticleFixture.LEO);
+        CommentCreateRequest request = LEO.getCommentCreateRequest();
+
+        // When
+        var response = invokePost(generateCommentRequestUri(article.getArticleId()), request);
+
+        //Then
+        CommentResponse actual = response.as(CommentResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(actual.getCommentId()).isEqualTo(1)
+        );
+    }
+
+    private static String generateCommentRequestUri(Long articleId) {
+        return "/api/articles/" + articleId + "/comments";
+    }
+}

--- a/src/test/java/com/yourssu/blog/model/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/yourssu/blog/model/repository/CommentRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.yourssu.blog.model.repository;
+
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.Comment;
+import com.yourssu.blog.support.common.fixture.ArticleFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Test
+    @DisplayName("댓글 번호에 맞는 댓글을 반환한다.")
+    void findById() {
+        Article article = articleRepository.save(ArticleFixture.LEO.getArticle());
+        Comment comment = LEO.getComment(article);
+
+        commentRepository.save(comment);
+
+        assertThatNoException().isThrownBy(
+                () -> commentRepository.get(1L)
+        );
+    }
+}

--- a/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
@@ -1,0 +1,38 @@
+package com.yourssu.blog.service;
+
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.repository.ArticleRepository;
+import com.yourssu.blog.service.dto.CommentSaveRequest;
+import com.yourssu.blog.support.common.fixture.ArticleFixture;
+import com.yourssu.blog.support.service.ApplicationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@ApplicationTest
+class CommentServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Test
+    @DisplayName("댓글을 생성한다.")
+    void save() {
+        Article article = saveArticle(ArticleFixture.LEO);
+        CommentSaveRequest request = LEO.getCommentSaveRequest(article);
+
+        assertThatNoException().isThrownBy(
+                () -> commentService.save(request)
+        );
+    }
+
+    private Article saveArticle(ArticleFixture article) {
+        return articleRepository.save(article.getArticle());
+    }
+}

--- a/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
@@ -1,0 +1,32 @@
+package com.yourssu.blog.support.common.fixture;
+
+import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.Comment;
+import com.yourssu.blog.service.dto.CommentSaveRequest;
+
+public enum CommentFixture {
+
+    LEO(UserFixture.LEO,
+            "leo comment");
+
+    private final UserFixture userFixture;
+    private final String content;
+
+    CommentFixture(UserFixture userFixture, String content) {
+        this.userFixture = userFixture;
+        this.content = content;
+    }
+
+    public Comment getComment(Article article) {
+        return new Comment(article, userFixture.getEmail(), content);
+    }
+
+    public CommentCreateRequest getCommentCreateRequest() {
+        return new CommentCreateRequest(userFixture.getEmail(), userFixture.getPassword(), content);
+    }
+
+    public CommentSaveRequest getCommentSaveRequest(Article article) {
+        return new CommentSaveRequest(article.getArticleId(), userFixture.getEmail(), userFixture.getPassword(), content);
+    }
+}


### PR DESCRIPTION
### 특이사항
- 게시글 작성 서비스 레이어의 메서드 단위 @ Transactional 중복을 제거한다.
- 댓글 작성 기능도 구현한다.
- 예외 처리는 구현하지 않는다.
- 게시글 존재와 작성자 일치 여부를 고려하지 않는다.

API 명세
1. POST /api/articles/{articleId} => 201 Created

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "content" : "content"
}
```

**Response Body**
```json
{
    "commentId" : 1,
    "email" : "email@urssu.com",
    "content" : "content"
}
```

2. GET /api/articles/{articleId}/comments/{commentId} => 200 OK

**Response Body**
```json
{
    "commentId" : 1,
    "email" : "email@urssu.com",
    "content" : "content"
}
```

