### PR TITLE
feat: 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/CommentController.java
+++ b/src/main/java/com/yourssu/blog/controller/CommentController.java
@@ -1,9 +1,11 @@
 package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.controller.dto.CommentEditRequest;
 import com.yourssu.blog.service.CommentService;
 import com.yourssu.blog.service.dto.CommentRequest;
 import com.yourssu.blog.service.dto.CommentResponse;
+import com.yourssu.blog.service.dto.CommentUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,5 +28,11 @@ public class CommentController {
     public ResponseEntity<CommentResponse> create(@PathVariable Long articleId, @RequestBody CommentCreateRequest request) {
         CommentResponse comment = commentService.save(request.toCommentSaveRequest(articleId));
         return ResponseEntity.status(HttpStatus.CREATED).body(comment);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> edit(@PathVariable Long articleId, @PathVariable Long commentId, @RequestBody CommentEditRequest request) {
+        CommentResponse response = commentService.update(request.toCommentUpdateRequest(articleId, commentId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/yourssu/blog/controller/dto/CommentEditRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/CommentEditRequest.java
@@ -1,0 +1,11 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.CommentRequest;
+import com.yourssu.blog.service.dto.CommentUpdateRequest;
+
+public record CommentEditRequest(String email, String password, String content) {
+
+    public CommentUpdateRequest toCommentUpdateRequest(Long articleId, Long commentId) {
+        return new CommentUpdateRequest(new CommentRequest(articleId, commentId), email, password, content);
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/Comment.java
+++ b/src/main/java/com/yourssu/blog/model/Comment.java
@@ -34,4 +34,8 @@ public class Comment extends BaseEntity {
         this.email = email;
         this.content = content;
     }
+
+    public void update(Comment comment) {
+        this.content = comment.content;
+    }
 }

--- a/src/main/java/com/yourssu/blog/service/CommentService.java
+++ b/src/main/java/com/yourssu/blog/service/CommentService.java
@@ -7,6 +7,7 @@ import com.yourssu.blog.model.repository.CommentRepository;
 import com.yourssu.blog.service.dto.CommentRequest;
 import com.yourssu.blog.service.dto.CommentResponse;
 import com.yourssu.blog.service.dto.CommentSaveRequest;
+import com.yourssu.blog.service.dto.CommentUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,13 @@ public class CommentService {
     public CommentResponse save(final CommentSaveRequest request) {
         Article article = articleRepository.get(request.articleId());
         Comment comment = commentRepository.save(request.getComment(article));
+        return CommentResponse.of(comment);
+    }
+
+    public CommentResponse update(final CommentUpdateRequest request) {
+        Article article = articleRepository.get(request.articleId());
+        Comment comment = commentRepository.get(request.commentId());
+        comment.update(request.getComment(article));
         return CommentResponse.of(comment);
     }
 }

--- a/src/main/java/com/yourssu/blog/service/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/CommentUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.Article;
+import com.yourssu.blog.model.Comment;
+
+public record CommentUpdateRequest(CommentRequest ids, String email, String password, String content) {
+
+    public Comment getComment(Article article) {
+        return new Comment(ids.commentId(), article, email, content);
+    }
+
+    public Long articleId() {
+        return ids.articleId();
+    }
+
+    public Long commentId() {
+        return ids.commentId();
+    }
+}

--- a/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
@@ -1,14 +1,18 @@
 package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.controller.dto.CommentEditRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.CommentResponse;
 import com.yourssu.blog.support.acceptance.AcceptanceTest;
 import com.yourssu.blog.support.common.fixture.ArticleFixture;
+import com.yourssu.blog.support.common.fixture.CommentFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePut;
+import static com.yourssu.blog.support.common.fixture.CommentFixture.EVOLVED_LEO;
 import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -34,7 +38,34 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @Test
+    void 댓글_수정을_요청한다() {
+        // Given
+        ArticleResponse article = ArticleAcceptanceTest.createArticle(ArticleFixture.LEO);
+        CommentResponse comment = createComment(article.getArticleId(), LEO);
+
+        // When
+        CommentEditRequest request = EVOLVED_LEO.getCommentEditRequest();
+
+        var response = invokePut(generateCommentRequestUri(article.getArticleId(), comment.getCommentId()), request);
+        CommentResponse actual = response.as(CommentResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(actual.getContent()).isEqualTo(request.content())
+        );
+    }
+
     private static String generateCommentRequestUri(Long articleId) {
         return "/api/articles/" + articleId + "/comments";
+    }
+
+    private static String generateCommentRequestUri(Long articleId, Long commentId) {
+        return "/api/articles/" + articleId + "/comments/" + commentId;
+    }
+
+    public static CommentResponse createComment(Long articleId, CommentFixture comment) {
+        CommentCreateRequest request = comment.getCommentCreateRequest();
+        return invokePost(generateCommentRequestUri(articleId), request).as(CommentResponse.class);
     }
 }

--- a/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
@@ -2,13 +2,16 @@ package com.yourssu.blog.service;
 
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.repository.ArticleRepository;
+import com.yourssu.blog.service.dto.CommentResponse;
 import com.yourssu.blog.service.dto.CommentSaveRequest;
+import com.yourssu.blog.service.dto.CommentUpdateRequest;
 import com.yourssu.blog.support.common.fixture.ArticleFixture;
 import com.yourssu.blog.support.service.ApplicationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static com.yourssu.blog.support.common.fixture.CommentFixture.EVOLVED_LEO;
 import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -29,6 +32,19 @@ class CommentServiceTest {
 
         assertThatNoException().isThrownBy(
                 () -> commentService.save(request)
+        );
+    }
+
+    @Test
+    @DisplayName("댓글을 수정한다.")
+    void update() {
+        Article article = saveArticle(ArticleFixture.LEO);
+        CommentResponse given = commentService.save(LEO.getCommentSaveRequest(article));
+
+        CommentUpdateRequest request = EVOLVED_LEO.getCommentUpdateRequest(article, given.getCommentId());
+
+        assertThatNoException().isThrownBy(
+                () -> commentService.update(request)
         );
     }
 

--- a/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/ArticleFixture.java
@@ -56,5 +56,4 @@ public enum ArticleFixture {
     public ArticleDeleteRequest getArticleDeleteRequest(Long articleId) {
         return new ArticleDeleteRequest(articleId, userFixture.getEmail(), userFixture.getPassword());
     }
-
 }

--- a/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
@@ -1,14 +1,19 @@
 package com.yourssu.blog.support.common.fixture;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
+import com.yourssu.blog.controller.dto.CommentEditRequest;
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.Comment;
+import com.yourssu.blog.service.dto.CommentRequest;
 import com.yourssu.blog.service.dto.CommentSaveRequest;
+import com.yourssu.blog.service.dto.CommentUpdateRequest;
 
 public enum CommentFixture {
 
     LEO(UserFixture.LEO,
-            "leo comment");
+            "leo comment"),
+    EVOLVED_LEO(UserFixture.LEO,
+            "leo evolved comment");
 
     private final UserFixture userFixture;
     private final String content;
@@ -28,5 +33,17 @@ public enum CommentFixture {
 
     public CommentSaveRequest getCommentSaveRequest(Article article) {
         return new CommentSaveRequest(article.getArticleId(), userFixture.getEmail(), userFixture.getPassword(), content);
+    }
+
+    public CommentEditRequest getCommentEditRequest() {
+        return new CommentEditRequest(userFixture.getEmail(), userFixture.getPassword(), content);
+    }
+
+    public CommentUpdateRequest getCommentUpdateRequest(Article article, Long commentId) {
+        return new CommentUpdateRequest(
+                new CommentRequest(article.getArticleId(), commentId),
+                userFixture.getEmail(),
+                userFixture.getPassword(),
+                content);
     }
 }


### PR DESCRIPTION
### 특이사항
- 댓글 수정 요청이 성공하는 경우만 고려하여 201 상태코드를 반환한다.
- 예외 상황을 고려하지 않는다.
- 수정 사항 없음&변경 되지 않을 경우 204 반환으로 변경 필요하다.
- 댓글 작성자와 일치 여부 및 회원가입 여부를 고려하지 않는다.

### API 명세
1. PUT /api/articles/{articleId}/comments/{commentId} => 201 Created

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "content" : "content-edited"
}
```

**Response Body**
```json
{
    "commentId" : 1,
    "email" : "email@urssu.com",
    "content" : "content-edited"
}
```