### PR TITLE
feat: 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/CommentController.java
+++ b/src/main/java/com/yourssu/blog/controller/CommentController.java
@@ -2,10 +2,10 @@ package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
 import com.yourssu.blog.controller.dto.CommentEditRequest;
+import com.yourssu.blog.controller.dto.CommentRemoveRequest;
 import com.yourssu.blog.service.CommentService;
 import com.yourssu.blog.service.dto.CommentRequest;
 import com.yourssu.blog.service.dto.CommentResponse;
-import com.yourssu.blog.service.dto.CommentUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,5 +34,11 @@ public class CommentController {
     public ResponseEntity<CommentResponse> edit(@PathVariable Long articleId, @PathVariable Long commentId, @RequestBody CommentEditRequest request) {
         CommentResponse response = commentService.update(request.toCommentUpdateRequest(articleId, commentId));
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable Long articleId, @PathVariable Long commentId, @RequestBody CommentRemoveRequest request) {
+        commentService.delete(request.toDeleteRequest(articleId, commentId));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/yourssu/blog/controller/dto/CommentRemoveRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/CommentRemoveRequest.java
@@ -1,0 +1,11 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.CommentDeleteRequest;
+import com.yourssu.blog.service.dto.CommentRequest;
+
+public record CommentRemoveRequest(String email, String password) {
+
+    public CommentDeleteRequest toDeleteRequest(Long articleId, Long commentId) {
+        return new CommentDeleteRequest(new CommentRequest(articleId, commentId), email, password);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/CommentService.java
+++ b/src/main/java/com/yourssu/blog/service/CommentService.java
@@ -4,10 +4,7 @@ import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.Comment;
 import com.yourssu.blog.model.repository.ArticleRepository;
 import com.yourssu.blog.model.repository.CommentRepository;
-import com.yourssu.blog.service.dto.CommentRequest;
-import com.yourssu.blog.service.dto.CommentResponse;
-import com.yourssu.blog.service.dto.CommentSaveRequest;
-import com.yourssu.blog.service.dto.CommentUpdateRequest;
+import com.yourssu.blog.service.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +34,10 @@ public class CommentService {
         Comment comment = commentRepository.get(request.commentId());
         comment.update(request.getComment(article));
         return CommentResponse.of(comment);
+    }
+
+    public void delete(CommentDeleteRequest request) {
+        Comment comment = commentRepository.get(request.commentId());
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/yourssu/blog/service/dto/CommentDeleteRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/CommentDeleteRequest.java
@@ -1,0 +1,8 @@
+package com.yourssu.blog.service.dto;
+
+public record CommentDeleteRequest(CommentRequest ids, String email, String password) {
+
+    public Long commentId() {
+        return ids.commentId();
+    }
+}

--- a/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/CommentAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.yourssu.blog.controller;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
 import com.yourssu.blog.controller.dto.CommentEditRequest;
+import com.yourssu.blog.controller.dto.CommentRemoveRequest;
 import com.yourssu.blog.service.dto.ArticleResponse;
 import com.yourssu.blog.service.dto.CommentResponse;
 import com.yourssu.blog.support.acceptance.AcceptanceTest;
@@ -10,8 +11,7 @@ import com.yourssu.blog.support.common.fixture.CommentFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
-import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePut;
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.*;
 import static com.yourssu.blog.support.common.fixture.CommentFixture.EVOLVED_LEO;
 import static com.yourssu.blog.support.common.fixture.CommentFixture.LEO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +53,22 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
                 () -> assertThat(actual.getContent()).isEqualTo(request.content())
+        );
+    }
+
+    @Test
+    void 댓글_삭제를_요청한다() {
+        // Given
+        ArticleResponse article = ArticleAcceptanceTest.createArticle(ArticleFixture.LEO);
+        CommentResponse comment = createComment(article.getArticleId(), LEO);
+
+        // When
+        CommentRemoveRequest request = LEO.getCommentRemoveRequest();
+
+        var response = invokeDelete(generateCommentRequestUri(article.getArticleId(), comment.getCommentId()), request);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
         );
     }
 

--- a/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/CommentServiceTest.java
@@ -2,9 +2,7 @@ package com.yourssu.blog.service;
 
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.repository.ArticleRepository;
-import com.yourssu.blog.service.dto.CommentResponse;
-import com.yourssu.blog.service.dto.CommentSaveRequest;
-import com.yourssu.blog.service.dto.CommentUpdateRequest;
+import com.yourssu.blog.service.dto.*;
 import com.yourssu.blog.support.common.fixture.ArticleFixture;
 import com.yourssu.blog.support.service.ApplicationTest;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +43,19 @@ class CommentServiceTest {
 
         assertThatNoException().isThrownBy(
                 () -> commentService.update(request)
+        );
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제한다.")
+    void delete() {
+        Article article = saveArticle(ArticleFixture.LEO);
+        CommentResponse given = commentService.save(LEO.getCommentSaveRequest(article));
+
+        CommentDeleteRequest request = LEO.getCommentDeleteRequest(article, given.getCommentId());
+
+        assertThatNoException().isThrownBy(
+                () -> commentService.delete(request)
         );
     }
 

--- a/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/CommentFixture.java
@@ -2,8 +2,10 @@ package com.yourssu.blog.support.common.fixture;
 
 import com.yourssu.blog.controller.dto.CommentCreateRequest;
 import com.yourssu.blog.controller.dto.CommentEditRequest;
+import com.yourssu.blog.controller.dto.CommentRemoveRequest;
 import com.yourssu.blog.model.Article;
 import com.yourssu.blog.model.Comment;
+import com.yourssu.blog.service.dto.CommentDeleteRequest;
 import com.yourssu.blog.service.dto.CommentRequest;
 import com.yourssu.blog.service.dto.CommentSaveRequest;
 import com.yourssu.blog.service.dto.CommentUpdateRequest;
@@ -45,5 +47,17 @@ public enum CommentFixture {
                 userFixture.getEmail(),
                 userFixture.getPassword(),
                 content);
+    }
+
+    public CommentRemoveRequest getCommentRemoveRequest() {
+        return new CommentRemoveRequest(userFixture.getEmail(), userFixture.getPassword());
+    }
+
+    public CommentDeleteRequest getCommentDeleteRequest(Article article, Long commentId) {
+        return new CommentDeleteRequest(
+                new CommentRequest(article.getArticleId(), commentId),
+                userFixture.getEmail(),
+                userFixture.getPassword()
+        );
     }
 }


### PR DESCRIPTION
### 특이사항
- 댓글이 무조건 삭제되는 경우만 고려하여 204 상태 코드를 반환한다.
- 예외 상황을 고려하지 않는다.
- 댓글 존재 여부와 댓글 작성자 일치 여부를 고려하지 않는다.
- 게시글 번호에 해당하는 댓글 여부를 고려하지 않는다.
- 인증, 인가 기능이 구현되면 RequestBody를 받는 현재 api를 Deprecated한다.

### API 명세
1. DELETE /api/articles/{articleId}/comments/{commentId} => 204 No Content

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
}
```