### PR TITLE
refactor: 게시글 기능 로직 단순화 및 메서드명 변경

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/ArticleController.java
+++ b/src/main/java/com/yourssu/blog/controller/ArticleController.java
@@ -25,7 +25,7 @@ public class ArticleController {
 
     @PostMapping
     public ResponseEntity<ArticleResponse> save(@RequestBody ArticleCreateRequest request) {
-        ArticleResponse article = articleService.saveArticle(request.toArticleSaveRequest());
+        ArticleResponse article = articleService.save(request.toArticleSaveRequest());
         return ResponseEntity.status(HttpStatus.CREATED).body(article);
     }
 

--- a/src/main/java/com/yourssu/blog/controller/ArticleController.java
+++ b/src/main/java/com/yourssu/blog/controller/ArticleController.java
@@ -31,7 +31,7 @@ public class ArticleController {
 
     @PutMapping("/{articleId}")
     public ResponseEntity<ArticleResponse> edit(@PathVariable Long articleId, @RequestBody ArticleEditRequest request) {
-        ArticleResponse article = articleService.update(request.toArticleUpdatedRequest(articleId));
+        ArticleResponse article = articleService.update(request.toArticleUpdateRequest(articleId));
         return ResponseEntity.status(HttpStatus.CREATED).body(article);
     }
 

--- a/src/main/java/com/yourssu/blog/controller/dto/ArticleEditRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/ArticleEditRequest.java
@@ -4,7 +4,7 @@ import com.yourssu.blog.service.dto.ArticleUpdateRequest;
 
 public record ArticleEditRequest(String email, String password, String title, String content) {
 
-    public ArticleUpdateRequest toArticleUpdatedRequest(Long articleId) {
+    public ArticleUpdateRequest toArticleUpdateRequest(Long articleId) {
         return new ArticleUpdateRequest(articleId, email, password, title, content);
     }
 }

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -30,10 +30,9 @@ public class ArticleService {
     }
 
     public ArticleResponse update(final ArticleUpdateRequest request) {
-        Article article = request.getArticle();
-        Article updatedArticle = articleRepository.get(article.getArticleId());
-        updatedArticle.update(article);
-        return ArticleResponse.of(updatedArticle);
+        Article article = articleRepository.get(request.articleId());
+        article.update(request.getArticle());
+        return ArticleResponse.of(article);
     }
 
     public void delete(final ArticleDeleteRequest request) {

--- a/src/main/java/com/yourssu/blog/service/ArticleService.java
+++ b/src/main/java/com/yourssu/blog/service/ArticleService.java
@@ -23,7 +23,7 @@ public class ArticleService {
         return ArticleResponse.of(article);
     }
 
-    public ArticleResponse saveArticle(final ArticleSaveRequest request) {
+    public ArticleResponse save(final ArticleSaveRequest request) {
         Article article = request.getArticle();
         Article savedArticle = articleRepository.save(article);
         return ArticleResponse.of(savedArticle);

--- a/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/ArticleServiceTest.java
@@ -24,14 +24,14 @@ class ArticleServiceTest {
         ArticleSaveRequest request = LEO.getArticleSaveRequest();
 
         assertThatNoException().isThrownBy(
-                () -> articleService.saveArticle(request)
+                () -> articleService.save(request)
         );
     }
 
     @Test
     @DisplayName("게시글을 수정한다.")
     void update() {
-        ArticleResponse given = articleService.saveArticle(LEO.getArticleSaveRequest());
+        ArticleResponse given = articleService.save(LEO.getArticleSaveRequest());
 
         ArticleUpdateRequest request = EVOLVED_LEO.getArticleUpdateRequest(given.getArticleId());
 
@@ -43,7 +43,7 @@ class ArticleServiceTest {
     @Test
     @DisplayName("게시글을 삭제한다.")
     void delete() {
-        ArticleResponse given = articleService.saveArticle(LEO.getArticleSaveRequest());
+        ArticleResponse given = articleService.save(LEO.getArticleSaveRequest());
 
         ArticleDeleteRequest request = LEO.getArticleDeleteRequest(given.getArticleId());
 


### PR DESCRIPTION
댓글 기능 개발 중에 발견한 리팩터링 요소들을 수정한다.

### 변경 목록
- 게시글 저장 기능 메서드 이름을 saveArticle => save로 변경한다.
- 게시글 수정 기능 메서드의 지역 변수를 단순화한다.
- 게시글 수정 기능 서비스 레이어 dto명을 변경한다.