### PR TITLE
feat: 회원가입, 인증(로그인) 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.google.guava:guava:33.3.0-jre'

--- a/src/main/java/com/yourssu/blog/config/support/Encrypt.java
+++ b/src/main/java/com/yourssu/blog/config/support/Encrypt.java
@@ -1,0 +1,41 @@
+package com.yourssu.blog.config.support;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+public class Encrypt {
+
+    private final String salt;
+
+    public Encrypt(@Value("${security.encrypt.salt}") final String salt) {
+        this.salt = salt;
+    }
+
+    public String encrypt(final String input) {
+        return sha256(input + salt);
+    }
+
+    private String sha256(final String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] result = digest.digest(input.getBytes());
+            return bytesToHex(result);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String bytesToHex(byte[] result) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : result) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/src/main/java/com/yourssu/blog/config/support/JwtTokenProvider.java
+++ b/src/main/java/com/yourssu/blog/config/support/JwtTokenProvider.java
@@ -1,0 +1,44 @@
+package com.yourssu.blog.config.support;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Jwts;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long expirationTime;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") final String secretKey,
+                            @Value("${security.jwt.token.expiration-time}") final Long expirationTime) {
+        this.secretKey = getSigningKey(secretKey);
+        this.expirationTime = expirationTime;
+    }
+
+    private static SecretKey getSigningKey(String secretKey) {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public String generateToken(Claims claims) {
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(new Date())
+                .expiration(new Date((new Date()).getTime() + expirationTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/yourssu/blog/controller/UserController.java
+++ b/src/main/java/com/yourssu/blog/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.yourssu.blog.controller;
+
+import com.yourssu.blog.controller.dto.AuthenticateRequest;
+import com.yourssu.blog.controller.dto.UserCreateRequest;
+import com.yourssu.blog.service.UserService;
+import com.yourssu.blog.service.dto.TokenResponse;
+import com.yourssu.blog.service.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserResponse> create(@RequestBody UserCreateRequest request) {
+        UserResponse response = userService.save(request.toUserSaveRequest());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<TokenResponse> authenticate(@RequestBody AuthenticateRequest request) {
+        TokenResponse response = userService.issueToken(request.toTokenIssueRequest());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/yourssu/blog/controller/dto/AuthenticateRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/AuthenticateRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.TokenIssueRequest;
+
+public record AuthenticateRequest(String email, String password) {
+
+    public TokenIssueRequest toTokenIssueRequest() {
+        return new TokenIssueRequest(email, password);
+    }
+}

--- a/src/main/java/com/yourssu/blog/controller/dto/UserCreateRequest.java
+++ b/src/main/java/com/yourssu/blog/controller/dto/UserCreateRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.controller.dto;
+
+import com.yourssu.blog.service.dto.UserSaveRequest;
+
+public record UserCreateRequest(String email, String password, String username) {
+
+    public UserSaveRequest toUserSaveRequest() {
+        return new UserSaveRequest(email, password, username);
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/Article.java
+++ b/src/main/java/com/yourssu/blog/model/Article.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "article")
 @Getter
 public class Article extends BaseEntity {
 

--- a/src/main/java/com/yourssu/blog/model/Comment.java
+++ b/src/main/java/com/yourssu/blog/model/Comment.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment")
 @Getter
 public class Comment extends BaseEntity {
 

--- a/src/main/java/com/yourssu/blog/model/User.java
+++ b/src/main/java/com/yourssu/blog/model/User.java
@@ -1,0 +1,38 @@
+package com.yourssu.blog.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "\"user\"")
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(name = "passsword", nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+    public User(String email, String password, String username) {
+        this(null, email, password, username);
+    }
+
+    public User(Long id, String email, String password, String username) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.username = username;
+    }
+}

--- a/src/main/java/com/yourssu/blog/model/User.java
+++ b/src/main/java/com/yourssu/blog/model/User.java
@@ -35,4 +35,10 @@ public class User extends BaseEntity {
         this.password = password;
         this.username = username;
     }
+
+    public void validatePassword(String password) {
+        if (!this.password.equals(password)) {
+            throw new IllegalArgumentException("Password does not match");
+        }
+    }
 }

--- a/src/main/java/com/yourssu/blog/model/repository/UserRepository.java
+++ b/src/main/java/com/yourssu/blog/model/repository/UserRepository.java
@@ -1,0 +1,21 @@
+package com.yourssu.blog.model.repository;
+
+import com.yourssu.blog.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("select u from User u where u.email = ?1")
+    Optional<User> findByEmail(String email);
+
+    default User get(Long id) {
+        return findById(id).orElseThrow(RuntimeException::new);
+    }
+
+    default User getByEmail(String email) {
+        return findByEmail(email).orElseThrow(RuntimeException::new);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/UserService.java
+++ b/src/main/java/com/yourssu/blog/service/UserService.java
@@ -1,5 +1,6 @@
 package com.yourssu.blog.service;
 
+import com.yourssu.blog.config.support.Encrypt;
 import com.yourssu.blog.config.support.JwtTokenProvider;
 import com.yourssu.blog.model.User;
 import com.yourssu.blog.model.repository.UserRepository;
@@ -21,15 +22,18 @@ public class UserService {
     private final UserRepository userRepository;
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final Encrypt encrypt;
 
 
-    public UserResponse save(UserSaveRequest userSaveRequest) {
-        User user = userRepository.save(userSaveRequest.toUser());
+    public UserResponse save(UserSaveRequest request) {
+        User user = new User(request.email(), encrypt.encrypt(request.password()), request.username());
+        userRepository.save(user);
         return UserResponse.of(user);
     }
 
     public TokenResponse issueToken(TokenIssueRequest request) {
         User user = userRepository.getByEmail(request.email());
+        user.validatePassword(encrypt.encrypt(request.password()));
         return TokenResponse.of(generateToken(user));
     }
 

--- a/src/main/java/com/yourssu/blog/service/UserService.java
+++ b/src/main/java/com/yourssu/blog/service/UserService.java
@@ -1,0 +1,44 @@
+package com.yourssu.blog.service;
+
+import com.yourssu.blog.config.support.JwtTokenProvider;
+import com.yourssu.blog.model.User;
+import com.yourssu.blog.model.repository.UserRepository;
+import com.yourssu.blog.service.dto.TokenIssueRequest;
+import com.yourssu.blog.service.dto.TokenResponse;
+import com.yourssu.blog.service.dto.UserResponse;
+import com.yourssu.blog.service.dto.UserSaveRequest;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public UserResponse save(UserSaveRequest userSaveRequest) {
+        User user = userRepository.save(userSaveRequest.toUser());
+        return UserResponse.of(user);
+    }
+
+    public TokenResponse issueToken(TokenIssueRequest request) {
+        User user = userRepository.getByEmail(request.email());
+        return TokenResponse.of(generateToken(user));
+    }
+
+    private String generateToken(User user) {
+        Claims claims = Jwts.claims()
+                .subject(String.valueOf(user.getId()))
+                .add("email", user.getEmail())
+                .add("username", user.getUsername())
+                .build();
+        return jwtTokenProvider.generateToken(claims);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/dto/TokenIssueRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/TokenIssueRequest.java
@@ -1,0 +1,4 @@
+package com.yourssu.blog.service.dto;
+
+public record TokenIssueRequest(String email, String password) {
+}

--- a/src/main/java/com/yourssu/blog/service/dto/TokenResponse.java
+++ b/src/main/java/com/yourssu/blog/service/dto/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.yourssu.blog.service.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TokenResponse {
+
+    private String token;
+
+    private TokenResponse(String token) {
+        this.token = token;
+    }
+
+    public static TokenResponse of(String token) {
+        return new TokenResponse(token);
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/dto/UserResponse.java
+++ b/src/main/java/com/yourssu/blog/service/dto/UserResponse.java
@@ -1,0 +1,23 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserResponse {
+
+    private String email;
+    private String username;
+
+    private UserResponse(String email, String username) {
+        this.email = email;
+        this.username = username;
+    }
+
+    public static UserResponse of(User user) {
+        return new UserResponse(user.getEmail(), user.getUsername());
+    }
+}

--- a/src/main/java/com/yourssu/blog/service/dto/UserSaveRequest.java
+++ b/src/main/java/com/yourssu/blog/service/dto/UserSaveRequest.java
@@ -1,0 +1,10 @@
+package com.yourssu.blog.service.dto;
+
+import com.yourssu.blog.model.User;
+
+public record UserSaveRequest(String email, String password, String username) {
+
+    public User toUser() {
+        return new User(email, password, username);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,3 +17,9 @@ spring:
     console:
       enabled: true
       path: /h2-console
+
+security:
+  jwt:
+    token:
+      secret-key: yourssu001yourssu002yourssu003yourssu004yourssu005
+      expiration-time: 3600000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,5 @@ security:
     token:
       secret-key: yourssu001yourssu002yourssu003yourssu004yourssu005
       expiration-time: 3600000
+  encrypt:
+    salt: yourssu001yourssu002yourssu003yourssu004

--- a/src/test/java/com/yourssu/blog/config/support/EncryptTest.java
+++ b/src/test/java/com/yourssu/blog/config/support/EncryptTest.java
@@ -1,0 +1,38 @@
+package com.yourssu.blog.config.support;
+
+import com.yourssu.blog.support.service.ApplicationTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@ApplicationTest
+class EncryptTest {
+
+    @Autowired
+    private Encrypt encrypt;
+
+    @Test
+    @DisplayName("문자열을 SHA-256 해시 알고리즘으로 암호화한다.")
+    void encrypt() {
+        String password = "yourssu2024";
+
+        assertThatNoException().isThrownBy(
+                () -> encrypt.encrypt(password));
+    }
+
+    @Test
+    @Disabled
+    @DisplayName("실제로 문자열을 SHA-256 해시 알고리즘으로 암호화한다. Salt가 변경되면 통과하지 않는다.")
+    void encryptWithSalt() {
+        String password = "yourssu2024";
+
+        String actual = encrypt.encrypt(password);
+
+        String expected = "9b09128cf76b491c12c57c796a87b56f71a207d8ccb2b5911c7c2029c6a6f150";
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/yourssu/blog/config/support/JwtTokenProviderTest.java
+++ b/src/test/java/com/yourssu/blog/config/support/JwtTokenProviderTest.java
@@ -1,0 +1,42 @@
+package com.yourssu.blog.config.support;
+
+import com.yourssu.blog.support.service.ApplicationTest;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@ApplicationTest
+class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("토큰을 생성한다.")
+    void generateToken() {
+        assertThatNoException().isThrownBy(
+                () -> jwtTokenProvider.generateToken(
+                        Jwts.claims()
+                        .build())
+        );
+    }
+
+    @Test
+    @DisplayName("토큰을 인증하고 payload를 반환한다.")
+    void extractAllClaims() {
+        final String expected = "This is a token.";
+        Claims claims = Jwts.claims()
+                .subject(expected)
+                .build();
+        String token = jwtTokenProvider.generateToken(claims);
+
+        String actual = jwtTokenProvider.extractAllClaims(token).getSubject();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/yourssu/blog/controller/UserAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/UserAcceptanceTest.java
@@ -1,0 +1,53 @@
+package com.yourssu.blog.controller;
+
+import com.yourssu.blog.controller.dto.UserCreateRequest;
+import com.yourssu.blog.service.dto.UserResponse;
+import com.yourssu.blog.support.acceptance.AcceptanceTest;
+import com.yourssu.blog.support.common.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
+import static com.yourssu.blog.support.common.fixture.UserFixture.LEO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class UserAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 회원_가입을_요청한다() {
+        // Given
+        UserCreateRequest request = LEO.getUserCreateRequest();
+
+        // When
+        var response = invokePost("/api/users", request);
+
+        //Then
+        UserResponse actual = response.as(UserResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(actual.getEmail()).isEqualTo(LEO.getEmail())
+        );
+    }
+
+    @Test
+    void 인증_토큰을_요청한다() {
+        // Given
+        createUser(LEO);
+
+        // When
+        var response = invokePost("/api/users/token", LEO.getAuthenticateRequest());
+
+        //Then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        );
+    }
+
+    public static UserResponse createUser(UserFixture user) {
+        UserCreateRequest request = user.getUserCreateRequest();
+        return invokePost("/api/users", request).as(UserResponse.class);
+    }
+}

--- a/src/test/java/com/yourssu/blog/model/repository/UserRepositoryTest.java
+++ b/src/test/java/com/yourssu/blog/model/repository/UserRepositoryTest.java
@@ -1,0 +1,40 @@
+package com.yourssu.blog.model.repository;
+
+import com.yourssu.blog.support.common.fixture.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원 번호와 일치하는 회원을 반환한다.")
+    void findById() {
+        UserFixture user = UserFixture.LEO;
+        userRepository.save(user.getUser());
+
+        assertThatNoException().isThrownBy(
+                () -> userRepository.get(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("이메일과 일치하는 회원을 반환한다.")
+    void findByEmail() {
+        UserFixture user = UserFixture.LEO;
+        userRepository.save(user.getUser());
+
+        assertThatNoException().isThrownBy(
+                () -> userRepository.getByEmail(user.getEmail())
+        );
+    }
+}

--- a/src/test/java/com/yourssu/blog/service/UserServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/UserServiceTest.java
@@ -1,0 +1,40 @@
+package com.yourssu.blog.service;
+
+import com.yourssu.blog.service.dto.TokenIssueRequest;
+import com.yourssu.blog.service.dto.UserSaveRequest;
+import com.yourssu.blog.support.service.ApplicationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.yourssu.blog.support.common.fixture.UserFixture.LEO;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@ApplicationTest
+public class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원을 생성한다.")
+    void save() {
+        UserSaveRequest request = LEO.getUserSaveRequest();
+
+        assertThatNoException().isThrownBy(
+                () -> userService.save(request)
+        );
+    }
+
+    @Test
+    @DisplayName("토큰을 발급한다.")
+    void issueToken() {
+        userService.save(LEO.getUserSaveRequest());
+
+        TokenIssueRequest request = LEO.getTokenIssueRequest();
+
+        assertThatNoException().isThrownBy(
+                () -> userService.issueToken(request)
+        );
+    }
+}

--- a/src/test/java/com/yourssu/blog/service/UserServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.yourssu.blog.service;
 
 import com.yourssu.blog.service.dto.TokenIssueRequest;
+import com.yourssu.blog.service.dto.TokenResponse;
 import com.yourssu.blog.service.dto.UserSaveRequest;
 import com.yourssu.blog.support.service.ApplicationTest;
 import org.junit.jupiter.api.DisplayName;
@@ -8,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.yourssu.blog.support.common.fixture.UserFixture.LEO;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static com.yourssu.blog.support.common.fixture.UserFixture.LEO_PASSWORD_INCORRECT;
+import static org.assertj.core.api.Assertions.*;
 
 @ApplicationTest
 public class UserServiceTest {
@@ -30,11 +32,22 @@ public class UserServiceTest {
     @DisplayName("토큰을 발급한다.")
     void issueToken() {
         userService.save(LEO.getUserSaveRequest());
-
         TokenIssueRequest request = LEO.getTokenIssueRequest();
 
-        assertThatNoException().isThrownBy(
-                () -> userService.issueToken(request)
-        );
+        TokenResponse response = userService.issueToken(request);
+
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 예외를 발생시킨다.")
+    void issueToken_invalidPassword() {
+        userService.save(LEO.getUserSaveRequest());
+
+        TokenIssueRequest request = LEO_PASSWORD_INCORRECT.getTokenIssueRequest();
+
+        assertThatThrownBy(
+                () -> userService.issueToken(request))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/yourssu/blog/support/common/DatabaseCleaner.java
+++ b/src/test/java/com/yourssu/blog/support/common/DatabaseCleaner.java
@@ -42,7 +42,7 @@ public class DatabaseCleaner implements InitializingBean {
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
             entityManager.createNativeQuery(
-                    "ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_id RESTART WITH 1").executeUpdate();
+                    "ALTER TABLE " + tableName + " ALTER COLUMN " + tableName.replace("\"", "") + "_id RESTART WITH 1").executeUpdate();
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }

--- a/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
@@ -11,6 +11,10 @@ public enum UserFixture {
     LEO("leo@yourssu.com",
             "leoPassword",
             "leo"
+    ),
+    LEO_PASSWORD_INCORRECT("leo@yourssu.com",
+                "incorrectPassword",
+                "leo"
     );
 
     private final String email;

--- a/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
@@ -1,20 +1,30 @@
 package com.yourssu.blog.support.common.fixture;
 
+import com.yourssu.blog.controller.dto.AuthenticateRequest;
+import com.yourssu.blog.controller.dto.UserCreateRequest;
+import com.yourssu.blog.model.User;
+import com.yourssu.blog.service.dto.TokenIssueRequest;
+import com.yourssu.blog.service.dto.UserSaveRequest;
+
 public enum UserFixture {
 
     LEO("leo@yourssu.com",
-            "leo",
-            "leoPassword"
+            "leoPassword",
+            "leo"
     );
 
     private final String email;
-    private final String name;
     private final String password;
+    private final String username;
 
-    UserFixture(String email, String name, String password) {
+    UserFixture(String email, String password, String username) {
         this.email = email;
-        this.name = name;
         this.password = password;
+        this.username = username;
+    }
+
+    public User getUser() {
+        return new User(email, password, username);
     }
 
     public String getEmail() {

--- a/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
+++ b/src/test/java/com/yourssu/blog/support/common/fixture/UserFixture.java
@@ -34,4 +34,20 @@ public enum UserFixture {
     public String getPassword() {
         return password;
     }
+
+    public UserCreateRequest getUserCreateRequest() {
+        return new UserCreateRequest(email, password, username);
+    }
+
+    public UserSaveRequest getUserSaveRequest() {
+        return new UserSaveRequest(email, password, username);
+    }
+
+    public AuthenticateRequest getAuthenticateRequest() {
+        return new AuthenticateRequest(email, password);
+    }
+
+    public TokenIssueRequest getTokenIssueRequest() {
+        return new TokenIssueRequest(email, password);
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,3 +20,5 @@ security:
     token:
       secret-key: yourssu001yourssu002yourssu003yourssu004yourssu005
       expiration-time: 3600000
+  encrypt:
+    salt: yourssu001yourssu002yourssu003yourssu004

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,22 @@
+server:
+  port: 3333
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+security:
+  jwt:
+    token:
+      secret-key: yourssu001yourssu002yourssu003yourssu004yourssu005
+      expiration-time: 3600000


### PR DESCRIPTION
### 특이사항
- 예외 처리는 고려하지 않는다.
- 회원가입은 이메일, 이름을 반환하고 로그인은 엑세스 토큰을 반환한다.
- 비밀번호를 SHA-256 해시 알고리즘으로 암호화한다.
- 비밀번호 일치 여부를 검증한다.
- 로컬, 테스트 환경 동작 yml 환경 변수도 github에 올린다.

### API 명세
1. 회원가입 POST /api/users => 201 Created

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
    "username" : "username"
}
```

**Response Body**
```json
{
    "email" : "email@urssu.com",
    "username" : "username"
}
```

2. 인증(로그인) POST /api/users/token => 200 OK

**Request Body**
```json
{
    "email" : "email@urssu.com",
    "password" : "password",
}
```

**Response Body**
```json
{
    "token": "Header.Payload.Signature"
}
```
