### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/yourssu/blog/controller/CommentController.java
+++ b/src/main/java/com/yourssu/blog/controller/CommentController.java
@@ -46,7 +46,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> delete(
+    public ResponseEntity<Void> remove(
             @PathVariable Long articleId,
             @PathVariable Long commentId,
             @LoginUserId Long userId) {

--- a/src/main/java/com/yourssu/blog/controller/UserController.java
+++ b/src/main/java/com/yourssu/blog/controller/UserController.java
@@ -28,4 +28,10 @@ public class UserController {
         TokenResponse response = userService.issueToken(request.toTokenIssueRequest());
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping()
+    public ResponseEntity<Void> remove(@LoginUserId Long userId) {
+        userService.delete(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/yourssu/blog/service/UserService.java
+++ b/src/main/java/com/yourssu/blog/service/UserService.java
@@ -45,4 +45,8 @@ public class UserService {
                 .build();
         return jwtTokenProvider.generateToken(claims);
     }
+
+    public void delete(Long userId) {
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/test/java/com/yourssu/blog/controller/UserAcceptanceTest.java
+++ b/src/test/java/com/yourssu/blog/controller/UserAcceptanceTest.java
@@ -9,6 +9,7 @@ import com.yourssu.blog.support.common.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokeDeleteWithToken;
 import static com.yourssu.blog.support.acceptance.AcceptanceContext.invokePost;
 import static com.yourssu.blog.support.common.fixture.UserFixture.LEO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +46,20 @@ public class UserAcceptanceTest extends AcceptanceTest {
         //Then
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        );
+    }
+
+    @Test
+    void 회원_삭제를_요청한다() {
+        // Given
+        createUser(UserFixture.LEO);
+        String token = authenticate(UserFixture.LEO).getToken();
+
+        // When
+        var response = invokeDeleteWithToken("/api/users", token);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
         );
     }
 

--- a/src/test/java/com/yourssu/blog/service/UserServiceTest.java
+++ b/src/test/java/com/yourssu/blog/service/UserServiceTest.java
@@ -1,8 +1,8 @@
 package com.yourssu.blog.service;
 
-import com.yourssu.blog.service.dto.TokenIssueRequest;
-import com.yourssu.blog.service.dto.TokenResponse;
-import com.yourssu.blog.service.dto.UserSaveRequest;
+import com.yourssu.blog.model.User;
+import com.yourssu.blog.model.repository.UserRepository;
+import com.yourssu.blog.service.dto.*;
 import com.yourssu.blog.support.service.ApplicationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +17,9 @@ public class UserServiceTest {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("회원을 생성한다.")
@@ -49,5 +52,15 @@ public class UserServiceTest {
         assertThatThrownBy(
                 () -> userService.issueToken(request))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("회원을 삭제한다.")
+    void delete() {
+        User user = userRepository.save(LEO.getUser());
+
+        assertThatNoException().isThrownBy(
+                () -> userService.delete(user.getId())
+        );
     }
 }


### PR DESCRIPTION
### 특이사항
- 회원 탈퇴시 게시글, 댓글 삭제 기능은 미구현한다.


1. 회원 탈퇴 기능 DELETE /api/users => 204 No Content
**Request**
-H "Authorization: Bearer {aaa.bbb.ccc}"